### PR TITLE
Add support for reverse-proxy S3 endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+
+- Added reverse-proxy / gateway routing via `GatewayConfig` and `S3Client.WithGateway(GatewayConfig)`
+
 ## v1.1.0 - 2026-05-18
 
 - Upgraded `RestWrapper` from `3.1.8` to `3.2.0`

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ S3Lite keeps the surface area small while still covering the core bucket and obj
 - AWS S3 and S3-compatible endpoint support
 - Anonymous access support for public buckets
 - Caller-supplied `HttpClient` support for DI, proxying, custom handlers, and connection reuse
+- Reverse-proxy / gateway routing that keeps the SigV4 signature bound to the upstream endpoint (useful for non-standard corporate reverse proxy configurations)
 - Multi-targeted package: `netstandard2.0`, `netstandard2.1`, `net8.0`, and `net10.0`
 
 ## New in v1.1.0
@@ -127,6 +128,45 @@ Notes:
 - S3Lite does not dispose a caller-supplied `HttpClient`
 - Transport behavior such as proxying, TLS, decompression, retries, and timeouts should be configured on your `HttpClient` or its handler
 
+## Routing Through a Reverse Proxy / Gateway
+
+Some environments require S3 traffic to egress through an intermediate host that forwards to the real endpoint. For example, `s3.gateway.example.com` can be configured to act as a reverse proxy to `s3.us-west-1.amazonaws.com`.
+
+SigV4 binds the signature to the request `Host`, so simply pointing the client at the gateway makes it sign for the gateway; once the gateway rewrites `Host` to the upstream endpoint, the signature no longer validates.
+
+`GatewayConfig` solves this. When set, S3Lite sends the request to the gateway while the SigV4 signature stays bound to the upstream endpoint configured via `WithHostname`. Attach it with `WithGateway`:
+
+```csharp
+using S3Lite;
+
+S3Client s3 = new S3Client()
+    .WithRegion("us-west-1")
+    .WithHostname("s3.us-west-1.amazonaws.com")   // the real upstream endpoint the signature is bound to
+    .WithPort(443)
+    .WithProtocol(ProtocolEnum.Https)
+    .WithRequestStyle(RequestStyleEnum.PathStyle)
+    .WithAccessKey("AKIAIOSFODNN7EXAMPLE")
+    .WithSecretKey("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+    .WithGateway(new GatewayConfig
+    {
+        Hostname = "s3.gateway.example.com",      // gateway host only, no scheme or port
+        Port = 8443,                              // omit (or 0) to reuse the client Port
+        Protocol = ProtocolEnum.Https             // omit (or null) to reuse the client Protocol
+    });
+
+bool exists = await s3.Bucket.ExistsAsync("my-bucket");
+```
+
+How it works:
+
+- The connection (scheme, host, port) is created for `https://s3.gateway.example.com`, so the gateway receives `Host=s3.gateway.example.com`.
+- The signature is computed for the **upstream request authority**, which is not necessarily `Hostname` verbatim. For `PathStyle` it is the endpoint (for example `s3.us-west-1.amazonaws.com`, including a non-standard port when configured); for `VirtualHostedStyle` it is bucket-prefixed (for example `my-bucket.s3.us-west-1.amazonaws.com`).
+- The gateway is expected to rewrite `Host` back to that upstream authority before forwarding upstream, so the signature validates. The path, query, and body are unchanged.
+
+`GatewayConfig.Hostname` must be the **gateway host only** — supply the protocol via `GatewayConfig.Protocol` and the port via `GatewayConfig.Port` separately. When `Protocol` is null or `Port` is 0, the client's own `Protocol` / `Port` values are reused. Leave `Gateway` unset (or `Hostname` empty) to send requests directly to `Hostname`.
+
+This is **not** a forward / HTTP (`CONNECT`) proxy. A forward proxy preserves the upstream `Host` end-to-end and needs no rewrite; to use one, leave `Gateway` unset and supply an `HttpClient` configured with a `WebProxy` via [`WithHttpClient`](#bring-your-own-httpclient) instead.
+
 ## Common Operations
 
 ### Service APIs
@@ -190,6 +230,7 @@ For S3-compatible platforms such as Less3, MinIO, or LocalStack, point `Hostname
 | `RequestStyle` | `VirtualHostedStyle` or `PathStyle` |
 | `SignatureVersion` | Signature version used by the client |
 | `HttpClient` | Optional caller-supplied `HttpClient` instance |
+| `Gateway` | Optional `GatewayConfig` for reverse-proxy / gateway routing while signing for the upstream `Hostname` |
 | `Logger` | Optional request logger callback |
 
 ## Error Behavior

--- a/src/S3Lite/GatewayConfig.cs
+++ b/src/S3Lite/GatewayConfig.cs
@@ -3,25 +3,32 @@ using System;
 namespace S3Lite
 {
     /// <summary>
-    /// Settings for routing requests through an intermediate gateway while signing for the upstream
-    /// <see cref="S3Client.Hostname" />.
+    /// Settings for routing requests through an intermediate reverse proxy / gateway while the SigV4 signature
+    /// stays bound to the upstream endpoint described by <see cref="S3Client.Hostname" />.
     /// Assign to <see cref="S3Client.Gateway" /> (or pass to <see cref="S3Client.WithGateway" />) to enable gateway routing.
-    ///
-    /// This describes a reverse proxy / gateway: the request is sent to this host with its Host header set
-    /// to this host, so the gateway is expected to rewrite the Host header to <see cref="S3Client.Hostname" />
-    /// before forwarding upstream. The SigV4 signature stays bound to <see cref="S3Client.Hostname" />, so it
-    /// validates once the gateway has rewritten the Host header.
-    ///
+    /// <para>
+    /// When set, the request is sent to this gateway host with its Host header set to this gateway host. The
+    /// gateway is expected to rewrite the Host header to the authority the request was signed for - the upstream
+    /// request authority - before forwarding upstream. That signed authority is not necessarily
+    /// <see cref="S3Client.Hostname" /> verbatim: for virtual-hosted-style requests it is bucket-prefixed
+    /// (for example <c>bucket.s3.us-west-1.example.com</c>), and for path-style requests it is the bare endpoint
+    /// (for example <c>s3.us-west-1.example.com</c>), including a non-standard port when one is configured. The
+    /// SigV4 signature stays bound to that upstream authority, so it validates once the gateway has restored it.
+    /// </para>
+    /// <para>
     /// This is NOT a forward/HTTP (CONNECT) proxy. For a forward proxy that preserves the upstream Host
     /// end-to-end, leave this unset and supply an HttpClient configured with a WebProxy instead
     /// (see <see cref="S3Client.WithHttpClient" />).
+    /// </para>
     /// </summary>
     public class GatewayConfig
     {
         #region Public-Members
 
         /// <summary>
-        /// Gateway hostname that requests are sent to.
+        /// Gateway host that requests are sent to. This must be the bare gateway host only (for example
+        /// <c>s3.gateway.example.com</c>); supply the protocol and port separately via <see cref="Protocol" />
+        /// and <see cref="Port" />.
         /// When null or empty, no gateway routing is performed and requests go directly to <see cref="S3Client.Hostname" />.
         /// </summary>
         public string Hostname { get; set; } = null;

--- a/src/S3Lite/GatewayConfig.cs
+++ b/src/S3Lite/GatewayConfig.cs
@@ -1,0 +1,71 @@
+using System;
+
+namespace S3Lite
+{
+    /// <summary>
+    /// Settings for routing requests through an intermediate gateway while signing for the upstream
+    /// <see cref="S3Client.Hostname" />.
+    /// Assign to <see cref="S3Client.Gateway" /> (or pass to <see cref="S3Client.WithGateway" />) to enable gateway routing.
+    ///
+    /// This describes a reverse proxy / gateway: the request is sent to this host with its Host header set
+    /// to this host, so the gateway is expected to rewrite the Host header to <see cref="S3Client.Hostname" />
+    /// before forwarding upstream. The SigV4 signature stays bound to <see cref="S3Client.Hostname" />, so it
+    /// validates once the gateway has rewritten the Host header.
+    ///
+    /// This is NOT a forward/HTTP (CONNECT) proxy. For a forward proxy that preserves the upstream Host
+    /// end-to-end, leave this unset and supply an HttpClient configured with a WebProxy instead
+    /// (see <see cref="S3Client.WithHttpClient" />).
+    /// </summary>
+    public class GatewayConfig
+    {
+        #region Public-Members
+
+        /// <summary>
+        /// Gateway hostname that requests are sent to.
+        /// When null or empty, no gateway routing is performed and requests go directly to <see cref="S3Client.Hostname" />.
+        /// </summary>
+        public string Hostname { get; set; } = null;
+
+        /// <summary>
+        /// Gateway port that requests are sent to.
+        /// When 0, the <see cref="S3Client.Port" /> value is used.
+        /// </summary>
+        public int Port
+        {
+            get
+            {
+                return _Port;
+            }
+            set
+            {
+                if (value < 0 || value > 65535) throw new ArgumentOutOfRangeException(nameof(Port));
+                _Port = value;
+            }
+        }
+
+        /// <summary>
+        /// Protocol (HTTP or HTTPS) used to reach the gateway.
+        /// When null, the <see cref="S3Client.Protocol" /> value is used.
+        /// </summary>
+        public ProtocolEnum? Protocol { get; set; } = null;
+
+        #endregion
+
+        #region Private-Members
+
+        private int _Port = 0;
+
+        #endregion
+
+        #region Constructors-and-Factories
+
+        /// <summary>
+        /// Instantiate.
+        /// </summary>
+        public GatewayConfig()
+        {
+        }
+
+        #endregion
+    }
+}

--- a/src/S3Lite/S3Client.cs
+++ b/src/S3Lite/S3Client.cs
@@ -181,10 +181,11 @@ namespace S3Lite
         }
 
         /// <summary>
-        /// Gateway settings used to route requests through an intermediate reverse proxy / gateway while
-        /// signing for <see cref="Hostname" />. The gateway is expected to rewrite the Host header to
-        /// <see cref="Hostname" /> before forwarding upstream. When null, requests are sent directly to
-        /// <see cref="Hostname" />.
+        /// Gateway settings used to route requests through an intermediate reverse proxy / gateway while the
+        /// SigV4 signature stays bound to the upstream endpoint described by <see cref="Hostname" />. The gateway
+        /// is expected to rewrite the Host header to the upstream request authority the signature was computed for
+        /// (bucket-prefixed for virtual-hosted-style, the bare endpoint - including any non-standard port - for
+        /// path-style) before forwarding upstream. When null, requests are sent directly to <see cref="Hostname" />.
         /// This is not a forward/HTTP (CONNECT) proxy; for that, supply an HttpClient configured with a
         /// WebProxy via <see cref="WithHttpClient" /> and leave this null.
         /// </summary>
@@ -420,9 +421,11 @@ namespace S3Lite
 
         /// <summary>
         /// Specify gateway settings used to route requests through an intermediate reverse proxy / gateway
-        /// while signing for <see cref="Hostname" />. The gateway is expected to rewrite the Host header to
-        /// <see cref="Hostname" /> before forwarding upstream. Pass null to send requests directly to
-        /// <see cref="Hostname" />.
+        /// while the SigV4 signature stays bound to the upstream endpoint described by <see cref="Hostname" />.
+        /// The gateway is expected to rewrite the Host header to the upstream request authority the signature
+        /// was computed for (bucket-prefixed for virtual-hosted-style, the bare endpoint - including any
+        /// non-standard port - for path-style) before forwarding upstream. Pass null to send requests directly
+        /// to <see cref="Hostname" />.
         /// This is not a forward/HTTP (CONNECT) proxy; for that, supply an HttpClient configured with a
         /// WebProxy via <see cref="WithHttpClient" /> and leave this null.
         /// </summary>
@@ -605,13 +608,16 @@ namespace S3Lite
 
             if (_Gateway != null && !String.IsNullOrEmpty(_Gateway.Hostname))
             {
-                // Redirect the connection (scheme/host/port) to the gateway while the signature stays
-                // bound to Hostname. The transport derives the Host header from this URL, so the gateway
-                // receives Host = the gateway host and is expected to rewrite it to Hostname before
-                // forwarding upstream (the corporate reverse-proxy case). The path, query, body, and
-                // signature are unchanged.
+                // Redirect the connection (scheme/host/port) to the gateway while the signature stays bound to
+                // the upstream request authority. The signature was already computed above from req.Url (the
+                // upstream URL), so its signed Host is the upstream authority - bucket.s3.region.hostname for
+                // virtual-hosted-style, or s3.region.hostname[:port] for path-style - not necessarily Hostname
+                // verbatim. The transport derives the Host header from this rewritten URL, so the gateway
+                // receives Host = the gateway host and is expected to rewrite it back to that upstream authority
+                // before forwarding upstream (the corporate reverse-proxy case). Only scheme/host/port change
+                // here; the path, query, body, and signature are untouched.
                 //
-                // This is not a forward/CONNECT proxy. For a forward proxy that must preserve Host = Hostname
+                // This is not a forward/CONNECT proxy. For a forward proxy that must preserve the upstream Host
                 // end-to-end, leave Gateway null and supply an HttpClient configured with a WebProxy
                 // (see WithHttpClient).
                 int gatewayPort = _Gateway.Port > 0 ? _Gateway.Port : _Port;

--- a/src/S3Lite/S3Client.cs
+++ b/src/S3Lite/S3Client.cs
@@ -1,4 +1,4 @@
-﻿namespace S3Lite
+namespace S3Lite
 {
     using System;
     using System.Collections.Generic;
@@ -181,6 +181,26 @@
         }
 
         /// <summary>
+        /// Gateway settings used to route requests through an intermediate reverse proxy / gateway while
+        /// signing for <see cref="Hostname" />. The gateway is expected to rewrite the Host header to
+        /// <see cref="Hostname" /> before forwarding upstream. When null, requests are sent directly to
+        /// <see cref="Hostname" />.
+        /// This is not a forward/HTTP (CONNECT) proxy; for that, supply an HttpClient configured with a
+        /// WebProxy via <see cref="WithHttpClient" /> and leave this null.
+        /// </summary>
+        public GatewayConfig Gateway
+        {
+            get
+            {
+                return _Gateway;
+            }
+            set
+            {
+                _Gateway = value;
+            }
+        }
+
+        /// <summary>
         /// Service APIs.
         /// </summary>
         public ServiceApis Service { get; private set; }
@@ -243,6 +263,7 @@
         private string _Region = "us-west-1";
         private string _Hostname = "amazonaws.com";
         private int _Port = 443;
+        private GatewayConfig _Gateway = null;
 
         private RequestStyleEnum _RequestStyle = RequestStyleEnum.VirtualHostedStyle;
         private SignatureVersionEnum _SignatureVersion = SignatureVersionEnum.Version4;
@@ -394,6 +415,22 @@
         public S3Client WithPort(int port)
         {
             _Port = port;
+            return this;
+        }
+
+        /// <summary>
+        /// Specify gateway settings used to route requests through an intermediate reverse proxy / gateway
+        /// while signing for <see cref="Hostname" />. The gateway is expected to rewrite the Host header to
+        /// <see cref="Hostname" /> before forwarding upstream. Pass null to send requests directly to
+        /// <see cref="Hostname" />.
+        /// This is not a forward/HTTP (CONNECT) proxy; for that, supply an HttpClient configured with a
+        /// WebProxy via <see cref="WithHttpClient" /> and leave this null.
+        /// </summary>
+        /// <param name="gateway">Gateway settings, or null to disable gateway routing.</param>
+        /// <returns>S3Client.</returns>
+        public S3Client WithGateway(GatewayConfig gateway)
+        {
+            _Gateway = gateway;
             return this;
         }
 
@@ -564,6 +601,26 @@
             else
             {
                 Logger?.Invoke(_Header + "anonymous access mode, skipping request signing");
+            }
+
+            if (_Gateway != null && !String.IsNullOrEmpty(_Gateway.Hostname))
+            {
+                // Redirect the connection (scheme/host/port) to the gateway while the signature stays
+                // bound to Hostname. The transport derives the Host header from this URL, so the gateway
+                // receives Host = the gateway host and is expected to rewrite it to Hostname before
+                // forwarding upstream (the corporate reverse-proxy case). The path, query, body, and
+                // signature are unchanged.
+                //
+                // This is not a forward/CONNECT proxy. For a forward proxy that must preserve Host = Hostname
+                // end-to-end, leave Gateway null and supply an HttpClient configured with a WebProxy
+                // (see WithHttpClient).
+                int gatewayPort = _Gateway.Port > 0 ? _Gateway.Port : _Port;
+                UriBuilder ub = new UriBuilder(req.Url);
+                if (_Gateway.Protocol.HasValue)
+                    ub.Scheme = _Gateway.Protocol.Value == ProtocolEnum.Https ? "https" : "http";
+                ub.Host = _Gateway.Hostname;
+                ub.Port = gatewayPort;
+                req.Url = ub.ToString();
             }
 
             RestResponse resp;

--- a/src/S3Lite/S3Lite.xml
+++ b/src/S3Lite/S3Lite.xml
@@ -884,6 +884,45 @@
             Instantiate.
             </summary>
         </member>
+        <member name="T:S3Lite.GatewayConfig">
+             <summary>
+             Settings for routing requests through an intermediate gateway while signing for the upstream
+             <see cref="P:S3Lite.S3Client.Hostname" />.
+             Assign to <see cref="P:S3Lite.S3Client.Gateway" /> (or pass to <see cref="M:S3Lite.S3Client.WithGateway(S3Lite.GatewayConfig)" />) to enable gateway routing.
+            
+             This describes a reverse proxy / gateway: the request is sent to this host with its Host header set
+             to this host, so the gateway is expected to rewrite the Host header to <see cref="P:S3Lite.S3Client.Hostname" />
+             before forwarding upstream. The SigV4 signature stays bound to <see cref="P:S3Lite.S3Client.Hostname" />, so it
+             validates once the gateway has rewritten the Host header.
+            
+             This is NOT a forward/HTTP (CONNECT) proxy. For a forward proxy that preserves the upstream Host
+             end-to-end, leave this unset and supply an HttpClient configured with a WebProxy instead
+             (see <see cref="M:S3Lite.S3Client.WithHttpClient(System.Net.Http.HttpClient)" />).
+             </summary>
+        </member>
+        <member name="P:S3Lite.GatewayConfig.Hostname">
+            <summary>
+            Gateway hostname that requests are sent to.
+            When null or empty, no gateway routing is performed and requests go directly to <see cref="P:S3Lite.S3Client.Hostname" />.
+            </summary>
+        </member>
+        <member name="P:S3Lite.GatewayConfig.Port">
+            <summary>
+            Gateway port that requests are sent to.
+            When 0, the <see cref="P:S3Lite.S3Client.Port" /> value is used.
+            </summary>
+        </member>
+        <member name="P:S3Lite.GatewayConfig.Protocol">
+            <summary>
+            Protocol (HTTP or HTTPS) used to reach the gateway.
+            When null, the <see cref="P:S3Lite.S3Client.Protocol" /> value is used.
+            </summary>
+        </member>
+        <member name="M:S3Lite.GatewayConfig.#ctor">
+            <summary>
+            Instantiate.
+            </summary>
+        </member>
         <member name="T:S3Lite.ObjectApis">
             <summary>
             Amazon S3 object APIs.
@@ -1044,6 +1083,16 @@
             Port.
             </summary>
         </member>
+        <member name="P:S3Lite.S3Client.Gateway">
+            <summary>
+            Gateway settings used to route requests through an intermediate reverse proxy / gateway while
+            signing for <see cref="P:S3Lite.S3Client.Hostname" />. The gateway is expected to rewrite the Host header to
+            <see cref="P:S3Lite.S3Client.Hostname" /> before forwarding upstream. When null, requests are sent directly to
+            <see cref="P:S3Lite.S3Client.Hostname" />.
+            This is not a forward/HTTP (CONNECT) proxy; for that, supply an HttpClient configured with a
+            WebProxy via <see cref="M:S3Lite.S3Client.WithHttpClient(System.Net.Http.HttpClient)" /> and leave this null.
+            </summary>
+        </member>
         <member name="P:S3Lite.S3Client.Service">
             <summary>
             Service APIs.
@@ -1161,6 +1210,18 @@
             Specify the port.
             </summary>
             <param name="port">Port.</param>
+            <returns>S3Client.</returns>
+        </member>
+        <member name="M:S3Lite.S3Client.WithGateway(S3Lite.GatewayConfig)">
+            <summary>
+            Specify gateway settings used to route requests through an intermediate reverse proxy / gateway
+            while signing for <see cref="P:S3Lite.S3Client.Hostname" />. The gateway is expected to rewrite the Host header to
+            <see cref="P:S3Lite.S3Client.Hostname" /> before forwarding upstream. Pass null to send requests directly to
+            <see cref="P:S3Lite.S3Client.Hostname" />.
+            This is not a forward/HTTP (CONNECT) proxy; for that, supply an HttpClient configured with a
+            WebProxy via <see cref="M:S3Lite.S3Client.WithHttpClient(System.Net.Http.HttpClient)" /> and leave this null.
+            </summary>
+            <param name="gateway">Gateway settings, or null to disable gateway routing.</param>
             <returns>S3Client.</returns>
         </member>
         <member name="M:S3Lite.S3Client.EnableSignatureDebug">

--- a/src/S3Lite/S3Lite.xml
+++ b/src/S3Lite/S3Lite.xml
@@ -885,24 +885,31 @@
             </summary>
         </member>
         <member name="T:S3Lite.GatewayConfig">
-             <summary>
-             Settings for routing requests through an intermediate gateway while signing for the upstream
-             <see cref="P:S3Lite.S3Client.Hostname" />.
-             Assign to <see cref="P:S3Lite.S3Client.Gateway" /> (or pass to <see cref="M:S3Lite.S3Client.WithGateway(S3Lite.GatewayConfig)" />) to enable gateway routing.
-            
-             This describes a reverse proxy / gateway: the request is sent to this host with its Host header set
-             to this host, so the gateway is expected to rewrite the Host header to <see cref="P:S3Lite.S3Client.Hostname" />
-             before forwarding upstream. The SigV4 signature stays bound to <see cref="P:S3Lite.S3Client.Hostname" />, so it
-             validates once the gateway has rewritten the Host header.
-            
-             This is NOT a forward/HTTP (CONNECT) proxy. For a forward proxy that preserves the upstream Host
-             end-to-end, leave this unset and supply an HttpClient configured with a WebProxy instead
-             (see <see cref="M:S3Lite.S3Client.WithHttpClient(System.Net.Http.HttpClient)" />).
-             </summary>
+            <summary>
+            Settings for routing requests through an intermediate reverse proxy / gateway while the SigV4 signature
+            stays bound to the upstream endpoint described by <see cref="P:S3Lite.S3Client.Hostname" />.
+            Assign to <see cref="P:S3Lite.S3Client.Gateway" /> (or pass to <see cref="M:S3Lite.S3Client.WithGateway(S3Lite.GatewayConfig)" />) to enable gateway routing.
+            <para>
+            When set, the request is sent to this gateway host with its Host header set to this gateway host. The
+            gateway is expected to rewrite the Host header to the authority the request was signed for - the upstream
+            request authority - before forwarding upstream. That signed authority is not necessarily
+            <see cref="P:S3Lite.S3Client.Hostname" /> verbatim: for virtual-hosted-style requests it is bucket-prefixed
+            (for example <c>bucket.s3.us-west-1.example.com</c>), and for path-style requests it is the bare endpoint
+            (for example <c>s3.us-west-1.example.com</c>), including a non-standard port when one is configured. The
+            SigV4 signature stays bound to that upstream authority, so it validates once the gateway has restored it.
+            </para>
+            <para>
+            This is NOT a forward/HTTP (CONNECT) proxy. For a forward proxy that preserves the upstream Host
+            end-to-end, leave this unset and supply an HttpClient configured with a WebProxy instead
+            (see <see cref="M:S3Lite.S3Client.WithHttpClient(System.Net.Http.HttpClient)" />).
+            </para>
+            </summary>
         </member>
         <member name="P:S3Lite.GatewayConfig.Hostname">
             <summary>
-            Gateway hostname that requests are sent to.
+            Gateway host that requests are sent to. This must be the bare gateway host only (for example
+            <c>s3.gateway.example.com</c>); supply the protocol and port separately via <see cref="P:S3Lite.GatewayConfig.Protocol" />
+            and <see cref="P:S3Lite.GatewayConfig.Port" />.
             When null or empty, no gateway routing is performed and requests go directly to <see cref="P:S3Lite.S3Client.Hostname" />.
             </summary>
         </member>
@@ -1085,10 +1092,11 @@
         </member>
         <member name="P:S3Lite.S3Client.Gateway">
             <summary>
-            Gateway settings used to route requests through an intermediate reverse proxy / gateway while
-            signing for <see cref="P:S3Lite.S3Client.Hostname" />. The gateway is expected to rewrite the Host header to
-            <see cref="P:S3Lite.S3Client.Hostname" /> before forwarding upstream. When null, requests are sent directly to
-            <see cref="P:S3Lite.S3Client.Hostname" />.
+            Gateway settings used to route requests through an intermediate reverse proxy / gateway while the
+            SigV4 signature stays bound to the upstream endpoint described by <see cref="P:S3Lite.S3Client.Hostname" />. The gateway
+            is expected to rewrite the Host header to the upstream request authority the signature was computed for
+            (bucket-prefixed for virtual-hosted-style, the bare endpoint - including any non-standard port - for
+            path-style) before forwarding upstream. When null, requests are sent directly to <see cref="P:S3Lite.S3Client.Hostname" />.
             This is not a forward/HTTP (CONNECT) proxy; for that, supply an HttpClient configured with a
             WebProxy via <see cref="M:S3Lite.S3Client.WithHttpClient(System.Net.Http.HttpClient)" /> and leave this null.
             </summary>
@@ -1215,9 +1223,11 @@
         <member name="M:S3Lite.S3Client.WithGateway(S3Lite.GatewayConfig)">
             <summary>
             Specify gateway settings used to route requests through an intermediate reverse proxy / gateway
-            while signing for <see cref="P:S3Lite.S3Client.Hostname" />. The gateway is expected to rewrite the Host header to
-            <see cref="P:S3Lite.S3Client.Hostname" /> before forwarding upstream. Pass null to send requests directly to
-            <see cref="P:S3Lite.S3Client.Hostname" />.
+            while the SigV4 signature stays bound to the upstream endpoint described by <see cref="P:S3Lite.S3Client.Hostname" />.
+            The gateway is expected to rewrite the Host header to the upstream request authority the signature
+            was computed for (bucket-prefixed for virtual-hosted-style, the bare endpoint - including any
+            non-standard port - for path-style) before forwarding upstream. Pass null to send requests directly
+            to <see cref="P:S3Lite.S3Client.Hostname" />.
             This is not a forward/HTTP (CONNECT) proxy; for that, supply an HttpClient configured with a
             WebProxy via <see cref="M:S3Lite.S3Client.WithHttpClient(System.Net.Http.HttpClient)" /> and leave this null.
             </summary>

--- a/src/Test.Shared/S3LiteSyntheticServer.cs
+++ b/src/Test.Shared/S3LiteSyntheticServer.cs
@@ -26,6 +26,7 @@ namespace Test.Shared
         private readonly SerializationHelper _Serializer = new SerializationHelper();
         private int _Disposed = 0;
         private Task _ListenerTask = Task.CompletedTask;
+        private string? _LastHostHeader = null;
 
         private S3LiteSyntheticServer(int port)
         {
@@ -63,6 +64,18 @@ namespace Test.Shared
             get
             {
                 return _Region;
+            }
+        }
+
+        /// <summary>
+        /// Host header value presented on the most recently handled request.
+        /// Used to verify the Host header a gateway-routed request carries.
+        /// </summary>
+        internal string? LastHostHeader
+        {
+            get
+            {
+                return _LastHostHeader;
             }
         }
 
@@ -546,6 +559,7 @@ namespace Test.Shared
         {
             try
             {
+                _LastHostHeader = context.Request.UserHostName;
                 Uri requestUrl = context.Request.Url ?? throw new InvalidOperationException("Request URL is null.");
                 string absolutePath = Uri.UnescapeDataString(requestUrl.AbsolutePath ?? "/");
                 Dictionary<string, string> query = ParseQueryString(requestUrl.Query);

--- a/src/Test.Shared/S3LiteSyntheticServer.cs
+++ b/src/Test.Shared/S3LiteSyntheticServer.cs
@@ -2,6 +2,7 @@ namespace Test.Shared
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Specialized;
     using System.IO;
     using System.Linq;
     using System.Net;
@@ -27,6 +28,9 @@ namespace Test.Shared
         private int _Disposed = 0;
         private Task _ListenerTask = Task.CompletedTask;
         private string? _LastHostHeader = null;
+        private string? _LastHttpMethod = null;
+        private string? _LastRawPathAndQuery = null;
+        private NameValueCollection? _LastRequestHeaders = null;
 
         private S3LiteSyntheticServer(int port)
         {
@@ -76,6 +80,41 @@ namespace Test.Shared
             get
             {
                 return _LastHostHeader;
+            }
+        }
+
+        /// <summary>
+        /// HTTP method of the most recently handled request.
+        /// </summary>
+        internal string? LastHttpMethod
+        {
+            get
+            {
+                return _LastHttpMethod;
+            }
+        }
+
+        /// <summary>
+        /// Raw (still percent-encoded) path and query of the most recently handled request.
+        /// Used to reconstruct the upstream URL a gateway-routed request was signed against.
+        /// </summary>
+        internal string? LastRawPathAndQuery
+        {
+            get
+            {
+                return _LastRawPathAndQuery;
+            }
+        }
+
+        /// <summary>
+        /// Headers presented on the most recently handled request.
+        /// Used to recompute the SigV4 signature a gateway-routed request carries.
+        /// </summary>
+        internal NameValueCollection? LastRequestHeaders
+        {
+            get
+            {
+                return _LastRequestHeaders;
             }
         }
 
@@ -560,7 +599,10 @@ namespace Test.Shared
             try
             {
                 _LastHostHeader = context.Request.UserHostName;
+                _LastHttpMethod = context.Request.HttpMethod;
+                _LastRequestHeaders = new NameValueCollection(context.Request.Headers);
                 Uri requestUrl = context.Request.Url ?? throw new InvalidOperationException("Request URL is null.");
+                _LastRawPathAndQuery = requestUrl.PathAndQuery;
                 string absolutePath = Uri.UnescapeDataString(requestUrl.AbsolutePath ?? "/");
                 Dictionary<string, string> query = ParseQueryString(requestUrl.Query);
 

--- a/src/Test.Shared/S3LiteTestSuites.Synthetic.cs
+++ b/src/Test.Shared/S3LiteTestSuites.Synthetic.cs
@@ -72,7 +72,8 @@ namespace Test.Shared
                 new TestCaseDescriptor(suiteId, "ObjectDeleteMissing", "Object.DeleteAsync succeeds when the object is already missing using " + modeLabel, ct => TestSyntheticObjectDeleteMissingAsync(mode, ct)),
                 new TestCaseDescriptor(suiteId, "ObjectSpecialCharacterKey", "Object APIs round-trip keys with spaces using " + modeLabel, ct => TestSyntheticObjectSpecialCharacterKeyAsync(mode, ct)),
                 new TestCaseDescriptor(suiteId, "ObjectVersionIdParameter", "Object APIs accept versionId query parameters using " + modeLabel, ct => TestSyntheticObjectVersionIdParameterAsync(mode, ct)),
-                new TestCaseDescriptor(suiteId, "ObjectWriteMissingBucket", "Object.WriteAsync reports NoSuchBucket using " + modeLabel, ct => TestSyntheticObjectWriteMissingBucketAsync(mode, ct))
+                new TestCaseDescriptor(suiteId, "ObjectWriteMissingBucket", "Object.WriteAsync reports NoSuchBucket using " + modeLabel, ct => TestSyntheticObjectWriteMissingBucketAsync(mode, ct)),
+                new TestCaseDescriptor(suiteId, "GatewayRouting", "Gateway routing sends to the gateway host while signing for the upstream hostname using " + modeLabel, ct => TestSyntheticGatewayRoutingAsync(mode, ct)),
             };
 
             if (mode == RequestTransportMode.External)
@@ -545,6 +546,52 @@ namespace Test.Shared
                 AssertByteArraysEqual(payload, downloaded, "round-trip payload");
                 AssertFalse(server.ObjectExists(_SyntheticBucketName, key), "Deleted object should be removed from the synthetic server.");
             }, cancellationToken).ConfigureAwait(false);
+        }
+
+        private static async Task TestSyntheticGatewayRoutingAsync(RequestTransportMode mode, CancellationToken cancellationToken)
+        {
+            await using S3LiteSyntheticServer server = await S3LiteSyntheticServer.StartAsync(cancellationToken).ConfigureAwait(false);
+            SeedSyntheticServer(server);
+
+            const string upstreamHostname = "s3.upstream.example";
+            HttpClient? httpClient = null;
+
+            try
+            {
+                if (mode == RequestTransportMode.External)
+                {
+                    httpClient = server.CreateHttpClient();
+                }
+
+                S3Client client = httpClient == null ? new S3Client() : new S3Client(httpClient);
+
+                client
+                    .WithHostname(upstreamHostname)
+                    .WithPort(443)
+                    .WithProtocol(ProtocolEnum.Https)
+                    .WithRegion(server.Region)
+                    .WithRequestStyle(RequestStyleEnum.PathStyle)
+                    .WithAccessKey("synthetic-access-key")
+                    .WithSecretKey("synthetic-secret-key")
+                    .WithGateway(new GatewayConfig
+                    {
+                        Hostname = server.Hostname,
+                        Port = server.Port,
+                        Protocol = ProtocolEnum.Http
+                    });
+
+                bool exists = await client.Bucket.ExistsAsync(_SyntheticBucketName, token: cancellationToken).ConfigureAwait(false);
+
+                AssertTrue(exists, "A request routed through the gateway host should reach the synthetic server.");
+                AssertEqual(
+                    server.Hostname + ":" + server.Port.ToString(),
+                    server.LastHostHeader,
+                    "The gateway should receive Host set to the gateway host; it is expected to rewrite Host to the upstream hostname before forwarding.");
+            }
+            finally
+            {
+                httpClient?.Dispose();
+            }
         }
 
         private static async Task TestSyntheticServiceListBucketsAsync(RequestTransportMode mode, CancellationToken cancellationToken)

--- a/src/Test.Shared/S3LiteTestSuites.Synthetic.cs
+++ b/src/Test.Shared/S3LiteTestSuites.Synthetic.cs
@@ -2,12 +2,14 @@ namespace Test.Shared
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Specialized;
     using System.Linq;
     using System.Net;
     using System.Net.Http;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
+    using AWSSignatureGenerator;
     using S3Lite;
     using S3Lite.ApiObjects;
     using Touchstone.Core;
@@ -73,7 +75,8 @@ namespace Test.Shared
                 new TestCaseDescriptor(suiteId, "ObjectSpecialCharacterKey", "Object APIs round-trip keys with spaces using " + modeLabel, ct => TestSyntheticObjectSpecialCharacterKeyAsync(mode, ct)),
                 new TestCaseDescriptor(suiteId, "ObjectVersionIdParameter", "Object APIs accept versionId query parameters using " + modeLabel, ct => TestSyntheticObjectVersionIdParameterAsync(mode, ct)),
                 new TestCaseDescriptor(suiteId, "ObjectWriteMissingBucket", "Object.WriteAsync reports NoSuchBucket using " + modeLabel, ct => TestSyntheticObjectWriteMissingBucketAsync(mode, ct)),
-                new TestCaseDescriptor(suiteId, "GatewayRouting", "Gateway routing sends to the gateway host while signing for the upstream hostname using " + modeLabel, ct => TestSyntheticGatewayRoutingAsync(mode, ct)),
+                new TestCaseDescriptor(suiteId, "GatewayRoutingPathStyle", "Gateway routing sends to the gateway host while the SigV4 signature stays bound to the path-style upstream authority (non-standard port) using " + modeLabel, ct => TestSyntheticGatewayRoutingPathStyleAsync(mode, ct)),
+                new TestCaseDescriptor(suiteId, "GatewayRoutingVirtualHosted", "Gateway routing keeps the SigV4 signature bound to the bucket-prefixed virtual-hosted upstream authority for a nested key using " + modeLabel, ct => TestSyntheticGatewayRoutingVirtualHostedAsync(mode, ct)),
             };
 
             if (mode == RequestTransportMode.External)
@@ -548,12 +551,18 @@ namespace Test.Shared
             }, cancellationToken).ConfigureAwait(false);
         }
 
-        private static async Task TestSyntheticGatewayRoutingAsync(RequestTransportMode mode, CancellationToken cancellationToken)
+        private const string _GatewayAccessKey = "synthetic-access-key";
+        private const string _GatewaySecretKey = "synthetic-secret-key";
+        private const string _GatewayUpstreamHostname = "s3.upstream.example";
+
+        private static async Task TestSyntheticGatewayRoutingPathStyleAsync(RequestTransportMode mode, CancellationToken cancellationToken)
         {
             await using S3LiteSyntheticServer server = await S3LiteSyntheticServer.StartAsync(cancellationToken).ConfigureAwait(false);
             SeedSyntheticServer(server);
 
-            const string upstreamHostname = "s3.upstream.example";
+            // A non-standard upstream port so the signed host authority is "s3.upstream.example:8443",
+            // not just the bare hostname; this exercises the port-bearing path-style authority.
+            const int upstreamPort = 8443;
             HttpClient? httpClient = null;
 
             try
@@ -566,13 +575,13 @@ namespace Test.Shared
                 S3Client client = httpClient == null ? new S3Client() : new S3Client(httpClient);
 
                 client
-                    .WithHostname(upstreamHostname)
-                    .WithPort(443)
+                    .WithHostname(_GatewayUpstreamHostname)
+                    .WithPort(upstreamPort)
                     .WithProtocol(ProtocolEnum.Https)
                     .WithRegion(server.Region)
                     .WithRequestStyle(RequestStyleEnum.PathStyle)
-                    .WithAccessKey("synthetic-access-key")
-                    .WithSecretKey("synthetic-secret-key")
+                    .WithAccessKey(_GatewayAccessKey)
+                    .WithSecretKey(_GatewaySecretKey)
                     .WithGateway(new GatewayConfig
                     {
                         Hostname = server.Hostname,
@@ -580,18 +589,208 @@ namespace Test.Shared
                         Protocol = ProtocolEnum.Http
                     });
 
-                bool exists = await client.Bucket.ExistsAsync(_SyntheticBucketName, token: cancellationToken).ConfigureAwait(false);
+                byte[] data = await client.Object.GetAsync(_SyntheticBucketName, _SyntheticHelloKey, token: cancellationToken).ConfigureAwait(false);
 
-                AssertTrue(exists, "A request routed through the gateway host should reach the synthetic server.");
+                AssertByteArraysEqual(GetBytes(_SyntheticHelloContent), data, "A request routed through the gateway host should reach the synthetic server and return the seeded object.");
                 AssertEqual(
                     server.Hostname + ":" + server.Port.ToString(),
                     server.LastHostHeader,
-                    "The gateway should receive Host set to the gateway host; it is expected to rewrite Host to the upstream hostname before forwarding.");
+                    "The gateway should receive Host set to the gateway host; it is expected to rewrite Host to the upstream authority before forwarding.");
+                AssertEqual(
+                    "/" + _SyntheticBucketName + "/" + _SyntheticHelloKey,
+                    server.LastRawPathAndQuery,
+                    "Gateway routing must not alter the request path or query.");
+
+                AssertGatewaySignatureBoundToUpstream(
+                    server,
+                    server.Region,
+                    ProtocolEnum.Https,
+                    _GatewayUpstreamHostname,
+                    upstreamPort);
             }
             finally
             {
                 httpClient?.Dispose();
             }
+        }
+
+        private static async Task TestSyntheticGatewayRoutingVirtualHostedAsync(RequestTransportMode mode, CancellationToken cancellationToken)
+        {
+            await using S3LiteSyntheticServer server = await S3LiteSyntheticServer.StartAsync(cancellationToken).ConfigureAwait(false);
+            SeedSyntheticServer(server);
+
+            HttpClient? httpClient = null;
+
+            try
+            {
+                if (mode == RequestTransportMode.External)
+                {
+                    httpClient = server.CreateHttpClient();
+                }
+
+                S3Client client = httpClient == null ? new S3Client() : new S3Client(httpClient);
+
+                client
+                    .WithHostname(_GatewayUpstreamHostname)
+                    .WithPort(443)
+                    .WithProtocol(ProtocolEnum.Https)
+                    .WithRegion(server.Region)
+                    .WithRequestStyle(RequestStyleEnum.VirtualHostedStyle)
+                    .WithAccessKey(_GatewayAccessKey)
+                    .WithSecretKey(_GatewaySecretKey)
+                    .WithGateway(new GatewayConfig
+                    {
+                        Hostname = server.Hostname,
+                        Port = server.Port,
+                        Protocol = ProtocolEnum.Http
+                    });
+
+                // A nested key so we also confirm URL mutation does not disturb path signing.
+                //
+                // In virtual-hosted style the bucket lives in the Host header (bucket.s3.region.hostname), which
+                // the gateway redirect replaces with the gateway host. The synthetic server resolves the bucket
+                // from the request path, so once the bucket has left the Host it 404s as NoSuchBucket - exactly
+                // as a path-routing endpoint would. That is expected here: this test verifies how the request is
+                // signed and addressed, not that this particular server can serve a virtual-hosted request, so we
+                // only require that the request was sent and captured.
+                await AssertThrowsAsync<WebException>(
+                    () => client.Object.GetAsync(_SyntheticBucketName, _SyntheticFolderKeyOne, token: cancellationToken)).ConfigureAwait(false);
+
+                AssertEqual(
+                    server.Hostname + ":" + server.Port.ToString(),
+                    server.LastHostHeader,
+                    "The gateway should receive Host set to the gateway host; it is expected to rewrite Host to the upstream authority before forwarding.");
+                AssertEqual(
+                    "/" + _SyntheticFolderKeyOne,
+                    server.LastRawPathAndQuery,
+                    "Virtual-hosted gateway routing keeps the bucket in the host and the key in the path unchanged.");
+
+                // For virtual-hosted style the signed authority is bucket-prefixed: bucket.s3.region.hostname.
+                string virtualHostedAuthority = _SyntheticBucketName + ".s3." + server.Region + "." + _GatewayUpstreamHostname;
+
+                AssertGatewaySignatureBoundToUpstream(
+                    server,
+                    server.Region,
+                    ProtocolEnum.Https,
+                    virtualHostedAuthority,
+                    443);
+            }
+            finally
+            {
+                httpClient?.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Proves the SigV4 signature carried by a gateway-routed request is bound to the upstream request
+        /// authority (the host the gateway is expected to restore), not to the gateway host the request was
+        /// physically sent to. Recomputes the signature against the upstream authority and confirms it matches
+        /// the signature the client sent, while the gateway authority does not - so a gateway that rewrites Host
+        /// back to the upstream authority yields a request that validates, and one that leaves the gateway host
+        /// in place does not.
+        /// </summary>
+        private static void AssertGatewaySignatureBoundToUpstream(
+            S3LiteSyntheticServer server,
+            string region,
+            ProtocolEnum upstreamProtocol,
+            string upstreamHost,
+            int upstreamPort)
+        {
+            NameValueCollection? received = server.LastRequestHeaders;
+            AssertNotNull(received, "captured gateway request headers");
+            AssertNotNull(server.LastHttpMethod, "captured gateway request method");
+            AssertNotNull(server.LastRawPathAndQuery, "captured gateway request path");
+
+            string? authorization = received!["Authorization"];
+            AssertNotNull(authorization, "captured gateway Authorization header");
+
+            string capturedSignature = ParseAuthorizationField(authorization!, "Signature=");
+            List<string> signedHeaders = ParseAuthorizationField(authorization!, "SignedHeaders=")
+                .Split(';')
+                .Select(static h => h.Trim())
+                .Where(static h => h.Length > 0)
+                .ToList();
+            AssertTrue(signedHeaders.Contains("host"), "The SigV4 SignedHeaders must include the host header.");
+
+            string method = server.LastHttpMethod!;
+            string pathAndQuery = server.LastRawPathAndQuery!;
+            string timestamp = received["x-amz-date"]
+                ?? throw new InvalidOperationException("The gateway request is missing the x-amz-date header.");
+
+            string upstreamSignature = RecomputeGatewaySignature(
+                received, signedHeaders, method, timestamp, region,
+                upstreamProtocol == ProtocolEnum.Https ? "https" : "http",
+                upstreamHost, upstreamPort, pathAndQuery);
+
+            AssertEqual(
+                capturedSignature,
+                upstreamSignature,
+                "The SigV4 signature must validate once the gateway rewrites Host to the upstream authority "
+                + upstreamHost + " (it is bound to the upstream request, not the gateway host).");
+
+            // Negative control: the signature must NOT match the gateway authority the request was sent to,
+            // confirming the binding is genuinely to the upstream authority rather than incidentally to any host.
+            string gatewayHost = server.Hostname;
+            int gatewayPort = server.Port;
+            string gatewaySignature = RecomputeGatewaySignature(
+                received, signedHeaders, method, timestamp, region,
+                "http", gatewayHost, gatewayPort, pathAndQuery);
+
+            AssertTrue(
+                !String.Equals(capturedSignature, gatewaySignature, StringComparison.Ordinal),
+                "The signature must not match the gateway authority " + gatewayHost + ":" + gatewayPort.ToString()
+                + "; otherwise the upstream would reject the forwarded request.");
+        }
+
+        private static string RecomputeGatewaySignature(
+            NameValueCollection received,
+            List<string> signedHeaders,
+            string method,
+            string timestamp,
+            string region,
+            string scheme,
+            string host,
+            int port,
+            string pathAndQuery)
+        {
+            bool isStandardPort = (scheme == "https" && port == 443) || (scheme == "http" && port == 80);
+            string authority = isStandardPort ? host : host + ":" + port.ToString();
+
+            NameValueCollection signingHeaders = new NameValueCollection();
+            foreach (string name in signedHeaders)
+            {
+                if (String.Equals(name, "host", StringComparison.OrdinalIgnoreCase))
+                    signingHeaders[name] = authority;
+                else
+                    signingHeaders[name] = received[name];
+            }
+
+            string fullUrl = scheme + "://" + host + ":" + port.ToString() + pathAndQuery;
+
+            V4SignatureResult signature = new V4SignatureResult(
+                timestamp,
+                method.ToUpperInvariant(),
+                fullUrl,
+                _GatewayAccessKey,
+                _GatewaySecretKey,
+                region,
+                "s3",
+                signingHeaders,
+                null);
+
+            return signature.Signature;
+        }
+
+        private static string ParseAuthorizationField(string authorization, string fieldPrefix)
+        {
+            int start = authorization.IndexOf(fieldPrefix, StringComparison.Ordinal);
+            if (start < 0) throw new InvalidOperationException("Authorization header is missing '" + fieldPrefix + "'.");
+            start += fieldPrefix.Length;
+
+            int end = authorization.IndexOf(',', start);
+            if (end < 0) end = authorization.Length;
+
+            return authorization.Substring(start, end - start).Trim();
         }
 
         private static async Task TestSyntheticServiceListBucketsAsync(RequestTransportMode mode, CancellationToken cancellationToken)


### PR DESCRIPTION
Some environments require S3 traffic to egress through an intermediate host (e.g. `s3.proxy.corpo.biz`) that forwards to the real endpoint (e.g. s3.upstream.com). Because SigV4 binds the Host header, naively retargeting the client at the gateway makes it sign for that gateway; the proxy then rewrites Host to the upstream, and the signature no longer validates.

This adds GatewayConfig and S3Client.WithGateway(). When set, the request URL (for TCP connection) is repointed at the gateway while the SigV4 signature stays bound to Hostname. The gateway receives Host = S3Lite.Gateway.Hostname and is expected to rewrite it to match S3Lite.Hostname before forwarding upstream.

Closes jchristn/S3Lite#3

P.S. There are no changes to README or CHANGELOG yet -- I'd like you to do those to make sure the phrasing is consistent and that the change clearly explains what's going on. Feel free to edit my repo, or suggest the changes in the comments for me to apply them.

Also, I noticed that there's inconsistency in line endings in the repo: some files are CRLF, some files are LF, and when I built the S3Lite.xml file from my Linux box it overwrote everything with LF and made the diffs noisy. To fix this, you'd need to add a gitattributes and renormalize the repo, which is a commit that would touch a lot of files. I can do it for you if you want. 